### PR TITLE
Check if CommNet is enabled while checking if we're connected.

### DIFF
--- a/OhScrap/ModuleUPFMEvents.cs
+++ b/OhScrap/ModuleUPFMEvents.cs
@@ -94,7 +94,7 @@ namespace OhScrap
             if (FlightGlobals.ActiveVessel.FindPartModuleImplementing<KerbalEVA>() == null)
             {
                 Debug.Log("[OhScrap]: Attempting Remote Repair");
-                if (!FlightGlobals.ActiveVessel.Connection.IsConnectedHome)
+                if (CommNet.CommNetScenario.CommNetEnabled && !FlightGlobals.ActiveVessel.Connection.IsConnectedHome)
                 {
                     ScreenMessages.PostScreenMessage("Vessel must be connected to Homeworld before remote repair can be attempted");
                     Debug.Log("[OhScrap]: Remote Repair aborted. Vessel not connected home");


### PR DESCRIPTION
I noticed with Kerbalism installed, attempting a remote repair always gave a "not connected to Homeworld" error. Tracking it down, it seems that Kerbalism disables the stock commnet in favour of its own, which causes "FlightGlobals.ActiveVessel.Connection.IsConnectedHome" to always return false.

This probably also happens if commnet is disabled in the difficulty settings, but I didn't check to be sure.

Adding a test if commnet is enabled as part of that seems to have fixed the problem; now it's giving me "cannot remote repair" messages instead.