### PR TITLE
Add missing comma to OhScrap.version 

### DIFF
--- a/GameData/Severedsolo/OhScrap/OhScrap.version
+++ b/GameData/Severedsolo/OhScrap/OhScrap.version
@@ -31,9 +31,7 @@
         "MAJOR" : 1,
         "MINOR" : 7,
         "PATCH" : 99
-    }
-
-
+    },
     "INSTALL_LOC":
     {
         "NAME":         "OhScrap",


### PR DESCRIPTION
In the current release there's a syntax error in the AVC version file.
A comma is missing between `KSP_VERSION_MAX` and the newly added `INSTALL_LOC`.

This PR adds the missing comma in.

Note that CKAN is failing to index the 2.0 release due to this.
Once the PR is merged you should either swap out the released zip, or do a new release (preferred).

(@HebaruSan FYI)